### PR TITLE
use types in new expression to support older unity versions

### DIFF
--- a/UnitySweeper/Editor/AssetCollector.cs
+++ b/UnitySweeper/Editor/AssetCollector.cs
@@ -11,8 +11,8 @@ namespace UnitySweeper
     {
         public const string EXPORT_XMP_PATH = "referencemap.xml";
 
-        public readonly List<string> deleteFileList = new();
-        private List<CollectionData> referenceCollection = new();
+        public readonly List<string> deleteFileList = new List<string>();
+        private List<CollectionData> referenceCollection = new List<CollectionData>();
 
         public bool useCodeStrip = true;
         public bool saveEditorExtensions = true;


### PR DESCRIPTION
Omitting the type in new expressions is a new feature in C# 9. Unity 2020.3 does not support C# 9 features.

This edit allows the asset to work in older unity versions.