### PR TITLE
Adds package.json to allow installing as UPM

### DIFF
--- a/UnitySweeper/Editor.meta
+++ b/UnitySweeper/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2233f1cdea0afa547bbea17a960b62c2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySweeper/Editor/AssetCollector.cs.meta
+++ b/UnitySweeper/Editor/AssetCollector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db50d27aedeac2b4883a735656bd6a77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySweeper/Editor/AssetReferenceCollection.cs.meta
+++ b/UnitySweeper/Editor/AssetReferenceCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 945ba9e8396fb85469f979e1d8546ce4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySweeper/Editor/ClassReferenceCollection.cs.meta
+++ b/UnitySweeper/Editor/ClassReferenceCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8321a0468395bd3468eb125e1a82675f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySweeper/Editor/CollectionData.cs.meta
+++ b/UnitySweeper/Editor/CollectionData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5318e0d5e3f54ea419e02b772f02ce41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySweeper/Editor/FindUnusedAssetsWindow.cs.meta
+++ b/UnitySweeper/Editor/FindUnusedAssetsWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b88e63c0896c7e4a88155818d426a49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySweeper/Editor/ShaderReferenceCollection.cs.meta
+++ b/UnitySweeper/Editor/ShaderReferenceCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ca7234eb820ed0488556faf60372e26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySweeper/package.json
+++ b/UnitySweeper/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "com.notion-theory.unity-sweeper",
+  "version": "1.0.0",
+  "displayName": "Unity Sweeper",
+  "description": "A utility that detects unused assets in your Unity project, removes them, and creates backup packages for future reference.",
+  "unity": "2019.4",
+  "keywords": [
+    "editor",
+    "utility",
+    "asset management",
+    "cleanup"
+  ],
+  "author": {
+    "name": "Notion Theory",
+    "url": "https://github.com/notiontheory"
+  },
+  "documentationUrl": "https://github.com/notiontheory/unity-sweeper",
+  "license": "MIT",
+  "dependencies": {},
+  "samples": []
+}

--- a/UnitySweeper/package.json.meta
+++ b/UnitySweeper/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a7ddb17152d4ef7419f1e03e40d27d44
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
First of all, I really love this package. I've already used it in tons of school projects.

But I personally prefer to install it as package, as that allow installing with a single command line, instead of copying it into Assets folder.

If you don't like so, you may just reject the PR. But if you like it, you can tweak the package.json description as you like, or add a dedicated #upm branch.

You can test installing the pkg from my forked repo, either by

Unity Editor
`https://github.com/Maoyeedy/unity-sweeper.git?path=UnitySweeper`

or OpenUPM CLI
`openupm add com.notion-theory.unity-sweeper@https://github.com/Maoyeedy/unity-sweeper.git?path=UnitySweeper`

